### PR TITLE
Fix ofono restart

### DIFF
--- a/ofono/modem.go
+++ b/ofono/modem.go
@@ -418,7 +418,9 @@ func (modem *Modem) getProperty(interfaceName, propertyName string) (*dbus.Varia
 }
 
 func (modem *Modem) Delete() {
-	modem.IdentityRemoved <- modem.identity
+	if modem.identity != "" {
+		modem.IdentityRemoved <- modem.identity
+	}
 	modem.modemSignal.Cancel()
 	modem.modemSignal.C = nil
 	modem.simSignal.Cancel()


### PR DESCRIPTION
Fixes nuntium when ofono orderly re-starts (e.g. "restart ofono OFONO_RIL_DEVICE=mtk" in arale).

However, the ofono SIGKILL case plus a re-spawn is not solved with this PR.

See https://bugs.launchpad.net/ubuntu/+source/nuntium/+bug/1441135