### PR TITLE
Wait when context failed to connect

### DIFF
--- a/ofono/modem.go
+++ b/ofono/modem.go
@@ -40,9 +40,10 @@ const (
 )
 
 const (
-	ofonoAttachInProgressError = "org.ofono.AttachInProgress"
-	ofonoInProgressError       = "org.ofono.InProgress"
+	ofonoAttachInProgressError = "org.ofono.Error.AttachInProgress"
+	ofonoInProgressError       = "org.ofono.Error.InProgress"
 	ofonoNotAttachedError      = "org.ofono.Error.NotAttached"
+	ofonoFailedError           = "org.ofono.Error.Failed"
 )
 
 type OfonoContext struct {
@@ -269,8 +270,16 @@ func (modem *Modem) DeactivateMMSContext(context OfonoContext) error {
 }
 
 func activationErrorNeedsWait(err error) bool {
+	// ofonoFailedError might be due to network issues or to wrong APN configuration.
+	// Retrying would not make sense for the latter, but we cannot distinguish
+	// and any possible delay retrying might cause would happen only the first time
+	// (provided we end up finding the right APN on the list so we save it as
+	// preferred).
 	if dbusErr, ok := err.(*dbus.Error); ok {
-		return dbusErr.Name == ofonoInProgressError || dbusErr.Name == ofonoAttachInProgressError || dbusErr.Name == ofonoNotAttachedError
+		return dbusErr.Name == ofonoInProgressError ||
+			dbusErr.Name == ofonoAttachInProgressError ||
+			dbusErr.Name == ofonoNotAttachedError ||
+			dbusErr.Name == ofonoFailedError
 	}
 	return false
 }


### PR DESCRIPTION
Add org.ofono.Error.Failed to the set of error that make nuntium wait before retrying to open a context. Also, fix wrong names for some ofono errors.