### PR TITLE
Set ofono's Preferred when context works

### DIFF
--- a/ofono/modem.go
+++ b/ofono/modem.go
@@ -295,6 +295,13 @@ func (context OfonoContext) toggleActive(state bool, conn *dbus.Connection) erro
 				time.Sleep(2 * time.Second)
 			}
 		} else {
+			// If it works we set it as preferred in ofono, provided it is not
+			// a combined context.
+			// TODO get rid of nuntium's internal preferred setting
+			if !context.isPreferred() && context.isTypeMMS() {
+				obj.Call(CONNECTION_CONTEXT_INTERFACE, "SetProperty",
+					"Preferred", dbus.Variant{true})
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
Set ofono's Preferred property when there is not a previous preferred context, the context has been found to work, and it is not a combined context.

This change is required to let the user see which MMS context is being used when starting the APN editor.